### PR TITLE
various

### DIFF
--- a/src/main.etk
+++ b/src/main.etk
@@ -18,11 +18,11 @@
         mod
 %end
         
-# If caller is from system, jump to update.
+# If caller is from system, jump to lbl_update.
 caller
 push20 0xfffffffffffffffffffffffffffffffffffffffe
 eq
-push1 update
+push1 lbl_update
 jumpi
 
 ########
@@ -32,13 +32,19 @@ jumpi
 # Check if calldata is less than 32 bytes
 push1 32        # [32]
 calldatasize    # [calldatasize, 32]
-lt              # [calldatasize < 32]
-push1 revert    # [revert_addr, calldatasize < 32]
+eq              # [calldatasize == 32]
+push1 load      # [revert_addr, calldatasize == 32]
+# Jump to continue if length-check passed, otherwise revert
 jumpi           # []
+%push0()
+%push0()
+revert
 
+
+load: 
 # Load stored timestamp.
-push3 historical_roots_modulus() # [hrm, time]
-%get_input()    # [time]
+push3 historical_roots_modulus() # [hrm]
+%get_input()    # [time, hrm]
 mod             # [time_index]
 dup1            # [time_index, time_index]
 sload           # [want, time_index]
@@ -47,7 +53,7 @@ sload           # [want, time_index]
 %get_input() # [got, want, time_index]
 eq              # [got == want, time_index]
 iszero          # [got != want, time_index]
-push1 revert    # [revert_addr, got != want, time_index]
+push1 exit      # [revert_addr, got != want, time_index]
 jumpi           # [time_index]
 
 # Extend index to get root index.
@@ -58,6 +64,7 @@ sload           # [root]
 %push0()        # [0, root]
 mstore          # []
 
+exit: 
 push1 32        # [size]
 %push0()        # [offset]
 return
@@ -66,7 +73,7 @@ return
 # UPDATE #
 ##########
 
-update:
+lbl_update:
 jumpdest
 timestamp               # [time]
 %get_timestamp_index()  # [time_index, time]
@@ -82,13 +89,3 @@ sstore
 %push0()
 %push0()
 return
-
-##########
-# REVERT #
-##########
-
-revert:
-jumpdest
-%push0()
-%push0()
-revert


### PR DESCRIPTION
This does a couple of things: it changes the previous behaviour on if the "is the stored timestamp == the desired timestamp", previously it did `revert`, which is not according to eip. Now it returns 32 zeroes. 
Thus I could remove the `revert` label, and inline it at the one place it was used. And now that jump turned out into an opposite-check, which fit will with adding the strict-check which otherwise incurred a `not` penalty. 

So this PR replaces #2. 