### PR TITLE
tests: add more coverage for ring buffer wrap arounds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: test
+
+on: workflow_dispatch
+
+env:
+  FOUNDRY_PROFILE: ci
+
+jobs:
+  check:
+    strategy:
+      fail-fast: true
+
+    name: Foundry project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Run Forge build
+        run: |
+          forge --version
+          forge build --sizes
+        id: build
+
+      - name: Run Forge tests
+        run: |
+          forge test -vvv
+        id: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: test
 
-on: workflow_dispatch
+on: [workflow_dispatch, pull_request, push]
 
 env:
   FOUNDRY_PROFILE: ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: test
 
-on: [workflow_dispatch, pull_request, push]
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, reopened]
+  push:
 
 env:
   FOUNDRY_PROFILE: ci

--- a/test/Contract.t.sol.in
+++ b/test/Contract.t.sol.in
@@ -65,14 +65,26 @@ contract ContractTest is Test {
     }
 
     function testReadWrongTimestamp() public {
+        // Set reasonable timestamp.
+        vm.warp(1641070800);
         uint256 time = block.timestamp;
 
         // Store timestamp and root at expected indexes.
         vm.store(unit, timestamp_idx(), bytes32(time));
         vm.store(unit, root_idx(), root);
 
-        // Read root associated with timestamp wrapped around rootmod once.
+        // Wrap around rootmod once forward.
         (bool ret, bytes memory data) = unit.call(bytes.concat(bytes32(time+rootmod)));
+        assertFalse(ret);
+        assertEq(data, hex"");
+
+        // Wrap around rootmod once backward.
+        (ret, data) = unit.call(bytes.concat(bytes32(time-rootmod)));
+        assertFalse(ret);
+        assertEq(data, hex"");
+
+        // Timestamp without any associated root.
+        (ret, data) = unit.call(bytes.concat(bytes32(time+1)));
         assertFalse(ret);
         assertEq(data, hex"");
     }


### PR DESCRIPTION
Tests wrapping around forward and backward, as well as timestamps with no related root.