### PR TITLE
Shave 1 gas using msize instead of push1 32 

### DIFF
--- a/src/main.etk
+++ b/src/main.etk
@@ -107,8 +107,8 @@ loadroot:
         mstore           # []
         
         # Return the root.
-        push1 32         # [size]
-        push0            # [offset, size]
+        msize            # [32]
+        push0            # [0, 32]
         return           # []
 
 submit:


### PR DESCRIPTION
h/t @philogy

Only use of memory in the whole contract is the proceeding `mstore` so this will always return 32.