### PR TITLE
update readme (todo: cfg)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ $ cargo install --features cli etk-asm etk-dasm
 To assemble `src/main.etk` you will need to invoke `eas`:
 
 ```console
-$ eas src/main.etk
-3373fffffffffffffffffffffffffffffffffffffffe14604457602036146024575f5ffd5b620180005f350680545f35146037575f5ffd5b6201800001545f5260205ff35b6201800042064281555f359062018000015500
+$  eas src/main.etk
+3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762016da0810690815414603c575f5ffd5b62016da001545f5260205ff35b5f5ffd5b62016da042064281555f359062016da0015500
 ```
 
 It's also possible to remove the `etk` preproccessing by doing a roundtrip --
@@ -31,7 +31,7 @@ $ disease --code 0x$(eas src/main.etk)
    0:   caller
    1:   push20 0xfffffffffffffffffffffffffffffffffffffffe
   16:   eq
-  17:   push1 0x44
+  17:   push1 0x4d # selector("swap26309536(address,address,uint256,uint256,uint256)")
   19:   jumpi
 
   1a:   push1 0x20
@@ -45,46 +45,57 @@ $ disease --code 0x$(eas src/main.etk)
   23:   revert
 
   24:   jumpdest
-  25:   push3 0x018000
-  29:   push0
-  2a:   calldataload
-  2b:   mod
-  2c:   dup1
-  2d:   sload
-  2e:   push0
-  2f:   calldataload
-  30:   eq
-  31:   push1 0x37
-  33:   jumpi
+  25:   push0
+  26:   calldataload
+  27:   dup1
+  28:   iszero
+  29:   push1 0x49
+  2b:   jumpi
 
-  34:   push0
-  35:   push0
-  36:   revert
+  2c:   push3 0x016da0
+  30:   dup2
+  31:   mod
+  32:   swap1
+  33:   dup2
+  34:   sload
+  35:   eq
+  36:   push1 0x3c
+  38:   jumpi
 
-  37:   jumpdest
-  38:   push3 0x018000
-  3c:   add
-  3d:   sload
-  3e:   push0
-  3f:   mstore
-  40:   push1 0x20
-  42:   push0
-  43:   return
+  39:   push0
+  3a:   push0
+  3b:   revert
 
-  44:   jumpdest
-  45:   push3 0x018000
-  49:   timestamp
-  4a:   mod
-  4b:   timestamp
-  4c:   dup2
-  4d:   sstore
-  4e:   push0
-  4f:   calldataload
-  50:   swap1
-  51:   push3 0x018000
-  55:   add
+  3c:   jumpdest
+  3d:   push3 0x016da0
+  41:   add
+  42:   sload
+  43:   push0
+  44:   mstore
+  45:   push1 0x20
+  47:   push0
+  48:   return
+
+  49:   jumpdest
+  4a:   push0
+  4b:   push0
+  4c:   revert
+
+  4d:   jumpdest
+  4e:   push3 0x016da0
+  52:   timestamp
+  53:   mod
+  54:   timestamp
+  55:   dup2
   56:   sstore
-  57:   stop
+  57:   push0
+  58:   calldataload
+  59:   swap1
+  5a:   push3 0x016da0
+  5e:   add
+  5f:   sstore
+  60:   stop
+
 ```
 
 ### Control-flow Graph

--- a/src/main.etk
+++ b/src/main.etk
@@ -37,8 +37,8 @@
         0xfffffffffffffffffffffffffffffffffffffffe
 %end
 
-# revert sets up and then executes a revert instruction.
-%macro revert()
+# m_revert sets up and then executes a revert(0,0) operation.
+%macro m_revert()
         push0           # [0]
         push0           # [0, 0]
         revert          # []
@@ -68,41 +68,41 @@ start:
         # Jump to continue if length-check passed, otherwise revert.
         push1 loadtime   # [loadtime_lbl, calldatasize == 32]
         jumpi            # []
-        %revert()        # []
+        %m_revert()        # []
 
 loadtime:
         jumpdest
 
-        # Load input.
+        # Load input (time).
         push0            # [0]
         calldataload     # [calldata[0..32]]
-        dup1             # [time]
+        dup1             # [input_timestamp, input_timestamp]
 
         # Verify input timestamp is non-zero.
-        iszero           # [time == 0, time]
-        push1 revert     # [revert_lbl, time == 0, time]
-        jumpi            # [time]
+        iszero             # [input_timestamp == 0, input_timestamp]
+        push1 lbl_revert   # [lbl_revert, input_timestamp == 0, input_timestamp]
+        jumpi              # [input_timestamp]
 
         # Compute the timestamp index and load from storage.
-        push3 buflen()   # [buflen, time]
-        dup2             # [time, buflen, time]
-        mod              # [time_index, time]
-        swap1            # [time, time_index]
-        dup2             # [time_index, time, time_index]
-        sload            # [timestamp, time, time_index]
+        push3 buflen()   # [buflen, input_timestamp]
+        dup2             # [input_timestamp, buflen, input_timestamp]
+        mod              # [time_index, input_timestamp]
+        swap1            # [input_timestamp, time_index]
+        dup2             # [time_index, input_timestamp, time_index]
+        sload            # [stored_timestamp, input_timestamp, time_index]
 
         # Verify stored timestamp matches input timestamp. It's possible these
         # don't match if the slot has been overwritten by the ring buffer or if
         # the timestamp input wasn't a valid previous timestamp.
-        eq               # [input == timestamp, time_index]
+        eq               # [stored_timestamp == input_timestamp, time_index]
         push1 loadroot   # [loadroot_lbl, input == timestamp, time_index]
         jumpi            # [time_index]
-        %revert()        # []
+        %m_revert()        # []
 
 
 loadroot:
         # Extend index to get root index.
-        jumpdest
+        jumpdest         # [time_index]
         push3 buflen()   # [buflen, time_index]
         add              # [root_index]
         sload            # [root]
@@ -116,9 +116,9 @@ loadroot:
         push0            # [offset, size]
         return           # []
 
-revert:
+lbl_revert:
         jumpdest
-        %revert()
+        %m_revert()
 
 submit:
         jumpdest         # []


### PR DESCRIPTION
This updates the Readme to contain the new code. 



It also changes some meta in the code (but this PR does not modfy the compiled code) I don't like that `revert` is a label, `revert()` is a macro, and, well, `revert` is also an opcode. So this PR disambiguates them